### PR TITLE
change URLs to new spaceapi.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         new TWEEN.Tween(globe).to({time: 0},500).easing(TWEEN.Easing.Cubic.EaseOut).start();
         globe.animate();
 
-        $.getJSON('http://openspace.slopjong.de/directory.json', function(urls) {
+        $.getJSON('http://spaceapi.net/directory.json', function(urls) {
           for (var name in urls) {
             $.getJSON(urls[name], function(data) {
               // TODO: Gracefully handle GET errors
@@ -95,7 +95,7 @@
     </div>
 
     <div id="blurbRight">
-      <p>Hacked up with <a href="http://hackerspaces.nl/spaceapi/" target="_blank">The HackerSpace Status API</a> and <a href="http://code.google.com/p/webgl-globe/" target="_blank">The WebGL Globe</a>.</p>
+      <p>Hacked up with <a href="http://spaceapi.net/" target="_blank">The HackerSpace Status API</a> and <a href="http://code.google.com/p/webgl-globe/" target="_blank">The WebGL Globe</a>.</p>
       <p><a href="https://github.com/joewalnes/hackerspace-globe" target="_blank">Code on GitHub</a>.</p>
       <p>By <a href="http://twitter.com/joewalnes" target="_blank">@joewalnes</a> (with inspiration from <a href="http://twitter.com/toba" target="_blank">@toba</a> and <a href="http://twitter.com/osi" target="_blank">@osi</a>).</p>
     </div>


### PR DESCRIPTION
This will hopefully be stable now, the old URL just 404s. See http://rohieb.github.io/hackerspace-globe/ for the live code.
